### PR TITLE
Bump dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+TARGET_MAX_CHAR_NUM=20
+help: ## Show help
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")-1); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+
+start-db: build ## Starts application inside docker
+	@docker-compose up -d db
+
+restart: build ## Restart all containers after recompiling
+	@echo "-------------- Starting Containers --------------"
+	@docker-compose -f ${DOCKER_COMPOSE_FILE_PATH} down
+	@docker-compose -f ${DOCKER_COMPOSE_FILE_PATH} build --no-cache
+	@docker-compose -f ${DOCKER_COMPOSE_FILE_PATH} up -d
+
+up: build ## Starts application inside docker
+	@docker-compose up -d
+
+build: ## Builds the application
+	@ps -ef | grep java
+	@./gradlew clean build
+
+stop: ## Stops all containers up
+	@docker-compose down
+	@echo "Containers stopped!"
+
+clean: ## Stops all containers and removes docker images, containers and networks for this stack
+	@docker-compose down --rmi all

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -2,7 +2,7 @@
 # Ktorplate - Template Ktor project
 
 ### Tech stack:
-* Kotlin
+* Kotlin (JDK 17)
 * [Koin](https://insert-koin.io/)
 * [Ktor](https://ktor.io)
 * [JetBrains Exposed](https://github.com/JetBrains/Exposed)

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -2,7 +2,7 @@
 # Ktorplate - Template Ktor project
 
 ### Tech stack:
-* Kotlin (JDK 17)
+* Kotlin (JDK 11)
 * [Koin](https://insert-koin.io/)
 * [Ktor](https://ktor.io)
 * [JetBrains Exposed](https://github.com/JetBrains/Exposed)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Ktorplate - Template para projetos Ktor
 
 ### Tech stack:
-* Kotlin
+* Kotlin (JDK 17)
 * [Koin](https://insert-koin.io/)
 * [Ktor](https://ktor.io)
 * [JetBrains Exposed](https://github.com/JetBrains/Exposed)
@@ -36,6 +36,3 @@ docker-compose stop
 
 ### Versionamento da Base
 Todas as alterações na base são versionadas com o [flyway](https://flywaydb.org/), então a cada alteração (DDL/DML) da base, é necessário adicionar um novo arquivo na pasta `resources/db/migration` contendo sua alteração. O build do gradle se encarregará de aplicar as alterações graças ao plugin do flyway.
-
-## ISSUES
-* Não tem testes (extremo vai cavalo)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Ktorplate - Template para projetos Ktor
 
 ### Tech stack:
-* Kotlin (JDK 17)
+* Kotlin (JDK 11)
 * [Koin](https://insert-koin.io/)
 * [Ktor](https://ktor.io)
 * [JetBrains Exposed](https://github.com/JetBrains/Exposed)

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -1,5 +1,3 @@
-val ktorVersion = "1.3.2"
-
 plugins {
     application
 }

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -23,9 +23,10 @@ dependencies {
 tasks.jar {
     archiveBaseName.set("app")
     archiveVersion.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
     manifest {
-        attributes(mapOf("Main-Class" to application.mainClassName))
+        attributes(mapOf("Main-Class" to application.mainClass))
     }
 
     from(Callable {

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 application {
-    mainClassName = "br.com.amz.ktorplate.application.Application"
+    mainClass.set("br.com.amz.ktorplate.application.Application")
 
     applicationDefaultJvmArgs = listOf(
         "-server",

--- a/application/src/main/resources/application.conf
+++ b/application/src/main/resources/application.conf
@@ -9,9 +9,9 @@ ktor {
 }
 
 db {
-    jdbcUrl = ${DB_URL}
-    dbUser = ${DB_USER}
-    dbPassword = ${DB_PASSWORD}
+    jdbcUrl = ${?DB_URL}
+    dbUser = ${?DB_USER}
+    dbPassword = ${?DB_PASSWORD}
 }
 
 jwt {
@@ -30,3 +30,8 @@ MAdeNNsFfywW+D57n/LIxG/CZkIcwflVvdRfulnvSdAI71Tg0dl4ivbmWDtpoSag
 rtWHOQW2IQLmqqaIH0UgUycCAwEAAQ==
 -----END PUBLIC KEY-----"""
 }
+
+# Default values in case of missing environment variables
+db.jdbcUrl = "jdbc:postgresql://localhost:5432/ktorplate"
+db.dbUser = "local"
+db.dbPassword = "local"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,9 @@ val configVersion = findProperty("config.version").toString()
 val coroutinesVersion = findProperty("coroutines.version").toString()
 val jbcryptVersion = findProperty("jbcrypt.version").toString()
 val logbackVersion = findProperty("logback.version").toString()
-val junitVersion = findProperty("junit.version").toString()
 val koinVersion = findProperty("koin.version").toString()
 val jvmTargetVersion = findProperty("jvm.version").toString()
+val kotlinVersion = findProperty("kotlin.version").toString()
 
 plugins {
     val kotlinVersion = "1.9.0"
@@ -36,7 +36,7 @@ subprojects {
 
         implementation("io.insert-koin:koin-core:$koinVersion")
 
-        testImplementation("junit:junit:$junitVersion")
+        testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     }
 
     tasks.compileKotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ val koinVersion = findProperty("koin.version").toString()
 val jvmTargetVersion = findProperty("jvm.version").toString()
 
 plugins {
-    val kotlinVersion = "1.3.72"
+    val kotlinVersion = "1.9.0"
     kotlin("jvm") version kotlinVersion
 }
 
@@ -41,7 +41,6 @@ subprojects {
 
     tasks.compileKotlin {
         kotlinOptions {
-            freeCompilerArgs = listOf("-Xjvm-default=enable")
             allWarningsAsErrors = true
             jvmTarget = jvmTargetVersion
         }
@@ -55,5 +54,13 @@ subprojects {
 
     sourceSets {
         getByName("main").java.srcDirs("src/main/kotlin")
+    }
+}
+
+configurations {
+    all {
+        resolutionStrategy {
+            failOnVersionConflict()
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -14,10 +13,6 @@ subprojects {
     group = "br.com.amz"
 
     apply(plugin = "kotlin")
-
-    repositories {
-        jcenter()
-    }
 
     dependencies {
         implementation(kotlin("stdlib"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ subprojects {
         implementation("ch.qos.logback:logback-classic:1.2.1")
 
         // Test suit
-        testImplementation("junit:junit:4.12")
+        testImplementation("junit:junit")
     }
 
     tasks.compileKotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,10 @@ subprojects {
 
     apply(plugin = "kotlin")
 
+    repositories {
+        mavenCentral()
+    }
+
     dependencies {
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
@@ -30,8 +34,7 @@ subprojects {
         implementation("ch.qos.logback:logback-classic:$logbackVersion")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
-        implementation("org.koin:koin-core:$koinVersion")
-        implementation("org.koin:koin-core-ext:$koinVersion")
+        implementation("io.insert-koin:koin-core:$koinVersion")
 
         testImplementation("junit:junit:$junitVersion")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,13 +41,13 @@ subprojects {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xjvm-default=enable")
             allWarningsAsErrors = true
-            jvmTarget = "11"
+            jvmTarget = "17"
         }
     }
 
     tasks.compileTestKotlin {
         kotlinOptions {
-            jvmTarget = "11"
+            jvmTarget = "17"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,14 @@
-val koinVersion = "2.1.6"
+val configVersion = findProperty("config.version").toString()
+val coroutinesVersion = findProperty("coroutines.version").toString()
+val jbcryptVersion = findProperty("jbcrypt.version").toString()
+val logbackVersion = findProperty("logback.version").toString()
+val junitVersion = findProperty("junit.version").toString()
+val koinVersion = findProperty("koin.version").toString()
+val jvmTargetVersion = findProperty("jvm.version").toString()
 
 plugins {
-    kotlin("jvm") version "1.3.72"
+    val kotlinVersion = "1.3.72"
+    kotlin("jvm") version kotlinVersion
 }
 
 repositories {
@@ -18,31 +25,28 @@ subprojects {
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("com.typesafe:config:1.4.0")
+        implementation("com.typesafe:config:$configVersion")
+        implementation("org.mindrot:jbcrypt:$jbcryptVersion")
+        implementation("ch.qos.logback:logback-classic:$logbackVersion")
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
-        // koin dependencies
         implementation("org.koin:koin-core:$koinVersion")
         implementation("org.koin:koin-core-ext:$koinVersion")
 
-        implementation("org.mindrot:jbcrypt:0.4")
-        implementation("ch.qos.logback:logback-classic:1.2.1")
-
-        // Test suit
-        testImplementation("junit:junit")
+        testImplementation("junit:junit:$junitVersion")
     }
 
     tasks.compileKotlin {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xjvm-default=enable")
             allWarningsAsErrors = true
-            jvmTarget = "17"
+            jvmTarget = jvmTargetVersion
         }
     }
 
     tasks.compileTestKotlin {
         kotlinOptions {
-            jvmTarget = "17"
+            jvmTarget = jvmTargetVersion
         }
     }
 

--- a/entity/src/main/kotlin/br/com/amz/ktorplate/user/User.kt
+++ b/entity/src/main/kotlin/br/com/amz/ktorplate/user/User.kt
@@ -1,7 +1,9 @@
 package br.com.amz.ktorplate.user
 
+import java.util.UUID
+
 data class User(
-    val id: Long? = null,
+    val id: UUID? = null,
     val name: String? = null,
     val email: String,
     val phone: String? = null,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ ktor.version=2.3.4
 koin.version=3.5.0
 
 # global dependencies
-config.version=1.4.0
+config.version=1.4.2
 coroutines.version=1.7.3
 jbcrypt.version=0.4
 logback.version=1.2.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # project structure
-jvm.version=17
-kotlin.version=1.3.72
-ktor.version=1.3.2
+jvm.version=11
+kotlin.version=1.9.0
+ktor.version=2.3.4
 koin.version=3.5.0
 
 # global dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ exposed.version=0.43.0
 flyway.version=9.22.2
 
 # usecase dependencies
-auth0.version=3.10.3
+auth0.version=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,10 +11,10 @@ jbcrypt.version=0.4
 logback.version=1.4.11
 
 # persistence dependencies
-hikari.version=3.4.5
-postgresql.version=42.2.2
+hikari.version=5.0.1
+postgresql.version=42.6.0
 exposed.version=0.43.0
-flyway.version=6.4.0
+flyway.version=9.22.2
 
 # usecase dependencies
 auth0.version=3.10.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ junit.version=4.12
 # persistence dependencies
 hikari.version=3.4.5
 postgresql.version=42.2.2
-exposed.version=0.17.7
+exposed.version=0.43.0
 flyway.version=6.4.0
 
 # usecase dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ config.version=1.4.2
 coroutines.version=1.7.3
 jbcrypt.version=0.4
 logback.version=1.4.11
-junit.version=4.12
 
 # persistence dependencies
 hikari.version=3.4.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+kotlin.code.style=official
+
 # project structure
 jvm.version=11
 kotlin.version=1.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ koin.version=3.5.0
 
 # global dependencies
 config.version=1.4.0
-coroutines.version=1.3.7
+coroutines.version=1.7.3
 jbcrypt.version=0.4
 logback.version=1.2.1
 junit.version=4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,21 @@
+# project structure
+jvm.version=17
+kotlin.version=1.3.72
+ktor.version=1.3.2
+koin.version=2.1.6
+
+# global dependencies
+config.version=1.4.0
+coroutines.version=1.3.7
+jbcrypt.version=0.4
+logback.version=1.2.1
+junit.version=4.12
+
+# persistence dependencies
+hikari.version=3.4.5
+postgresql.version=42.2.2
+exposed.version=0.17.7
+flyway.version=6.4.0
+
+# usecase dependencies
+auth0.version=3.10.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ koin.version=3.5.0
 config.version=1.4.2
 coroutines.version=1.7.3
 jbcrypt.version=0.4
-logback.version=1.2.1
+logback.version=1.4.11
 junit.version=4.12
 
 # persistence dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 jvm.version=17
 kotlin.version=1.3.72
 ktor.version=1.3.2
-koin.version=2.1.6
+koin.version=3.5.0
 
 # global dependencies
 config.version=1.4.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 dependencies {
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.postgresql:postgresql:$postgresqlVersion")
-    implementation("org.jetbrains.exposed:exposed:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.flywaydb:flyway-core:$flywayVersion")
 
     implementation(project(":usecase"))

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -1,12 +1,18 @@
+val hikariVersion = findProperty("hikari.version").toString()
+val postgresqlVersion = findProperty("postgresql.version").toString()
+val exposedVersion = findProperty("exposed.version").toString()
+val flywayVersion = findProperty("flyway.version").toString()
+
 plugins {
-    id("org.flywaydb.flyway") version "6.4.0"
+    val flywayVersion = "6.4.0"
+    id("org.flywaydb.flyway") version flywayVersion
 }
 
 dependencies {
-    implementation("com.zaxxer:HikariCP:3.4.3")
-    implementation("org.postgresql:postgresql:42.2.2")
-    implementation("org.jetbrains.exposed:exposed:0.17.7")
-    implementation("org.flywaydb:flyway-core:6.4.0")
+    implementation("com.zaxxer:HikariCP:$hikariVersion")
+    implementation("org.postgresql:postgresql:$postgresqlVersion")
+    implementation("org.jetbrains.exposed:exposed:$exposedVersion")
+    implementation("org.flywaydb:flyway-core:$flywayVersion")
 
     implementation(project(":usecase"))
     implementation(project(":entity"))

--- a/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/config/DatabaseFactory.kt
+++ b/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/config/DatabaseFactory.kt
@@ -4,10 +4,9 @@ import com.typesafe.config.ConfigFactory
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 
 object DatabaseFactory {
     private val env = ConfigFactory.load()
@@ -45,8 +44,5 @@ object DatabaseFactory {
      * In order to help make non-blocking queries, this function starts a coroutine for each
      * query that runs on a special thread pool "Dispatcher.IO", that is optimised for IO heavy operations.
      * */
-    suspend fun <T> query(block: () -> T): T =
-        withContext(Dispatchers.IO) {
-            transaction { block() }
-        }
+    suspend fun <T> query(block: suspend () -> T): T = newSuspendedTransaction(Dispatchers.IO) { block() }
 }

--- a/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/entity/Users.kt
+++ b/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/entity/Users.kt
@@ -1,13 +1,16 @@
 package br.com.amz.ktorplate.persistence.entity
 
+import java.util.UUID
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
 
 object Users: Table() {
-    val id: Column<Long> = long("id").autoIncrement().primaryKey()
+    val id: Column<UUID> = uuid("id").autoGenerate()
     val name: Column<String> = varchar("name", 100)
     val email: Column<String> = varchar("email", 100)
     val phone: Column<String> = varchar("phone", 30)
     val password: Column<String> = varchar("password", 100)
     val active: Column<Boolean> = bool("active")
+
+    override val primaryKey = PrimaryKey(id)
 }

--- a/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/repository/UserRepository.kt
+++ b/persistence/src/main/kotlin/br/com/amz/ktorplate/persistence/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package br.com.amz.ktorplate.persistence.repository
 
-import br.com.amz.ktorplate.persistence.config.DatabaseFactory
+import br.com.amz.ktorplate.persistence.config.DatabaseFactory.query
 import br.com.amz.ktorplate.persistence.entity.Users
 import br.com.amz.ktorplate.persistence.utils.toUser
 import br.com.amz.ktorplate.usecases.adapter.UserAdapter
@@ -11,15 +11,15 @@ import org.jetbrains.exposed.sql.selectAll
 import org.mindrot.jbcrypt.BCrypt
 
 class UserRepository : UserAdapter {
-    override suspend fun findAll() = DatabaseFactory.query { Users.selectAll().map { it.toUser() } }
+    override suspend fun findAll() = query { Users.selectAll().map { it.toUser() } }
 
-    override suspend fun findByEmail(email: String) = DatabaseFactory.query {
+    override suspend fun findByEmail(email: String) = query {
         Users.select { (Users.email eq email) }
             .mapNotNull { it.toUser() }
             .singleOrNull()
     }
 
-    override suspend fun save(user: User) = DatabaseFactory.query {
+    override suspend fun save(user: User) = query {
         Users.insert {
             it[name] = user.name ?: ""
             it[email] = user.email

--- a/usecase/build.gradle.kts
+++ b/usecase/build.gradle.kts
@@ -1,5 +1,7 @@
+val auth0Version = findProperty("auth0.version").toString()
+
 dependencies {
     implementation(project(":entity"))
 
-    implementation("com.auth0:java-jwt:3.10.3")
+    implementation("com.auth0:java-jwt:$auth0Version")
 }

--- a/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/adapter/UserAdapter.kt
+++ b/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/adapter/UserAdapter.kt
@@ -1,11 +1,12 @@
 package br.com.amz.ktorplate.usecases.adapter
 
 import br.com.amz.ktorplate.user.User
+import java.util.UUID
 
 interface UserAdapter {
     suspend fun findAll(): List<User>
 
     suspend fun findByEmail(email: String): User?
 
-    suspend fun save(user: User): Long
+    suspend fun save(user: User): UUID
 }

--- a/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/config/JWTCredential.kt
+++ b/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/config/JWTCredential.kt
@@ -3,13 +3,14 @@ package br.com.amz.ktorplate.usecases.config
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import java.util.Date
+import java.util.UUID
 
 class JWTCredential(secret: String) {
     private val algorithm = Algorithm.HMAC256(secret)
     val verifier = JWT.require(algorithm).build()!!
 
-    fun sign(userId: Long) = JWT.create()
-        .withClaim("userId", userId)
+    fun sign(userId: UUID) = JWT.create()
+        .withClaim("userId", userId.toString())
         .withExpiresAt(getExpiration())
         .sign(algorithm)!!
 

--- a/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/service/LoginService.kt
+++ b/usecase/src/main/kotlin/br/com/amz/ktorplate/usecases/service/LoginService.kt
@@ -6,6 +6,7 @@ import br.com.amz.ktorplate.usecases.adapter.UserAdapter
 import br.com.amz.ktorplate.usecases.config.JWTCredential
 import br.com.amz.ktorplate.user.User
 import com.typesafe.config.Config
+import java.util.UUID
 import org.mindrot.jbcrypt.BCrypt
 
 class LoginService(
@@ -15,7 +16,7 @@ class LoginService(
 
     private val credential = JWTCredential(config.getString("jwt.secret"))
 
-    suspend fun register(user: User): Long = userAdapter.save(user)
+    suspend fun register(user: User): UUID = userAdapter.save(user)
 
     @Throws(UnauthorizedException::class)
     suspend fun login(user: User): String {

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation("io.ktor:ktor-gson:$ktorVersion")
     implementation("io.ktor:ktor-locations:$ktorVersion")
     implementation("io.ktor:ktor-auth-jwt:$ktorVersion")
-    implementation("org.koin:koin-ktor:$koinVersion")
+    implementation("io.insert-koin:koin-ktor:$koinVersion")
 
     testImplementation("io.ktor:ktor-server-tests:$ktorVersion")
 }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -1,5 +1,5 @@
-val ktorVersion = "1.3.2"
-val koinVersion = "2.1.6"
+val ktorVersion = findProperty("ktor.version").toString()
+val koinVersion = findProperty("koin.version").toString()
 
 dependencies {
     implementation(project(":usecase"))

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -5,11 +5,16 @@ dependencies {
     implementation(project(":usecase"))
     implementation(project(":entity"))
 
-    implementation("io.ktor:ktor-server-netty:$ktorVersion")
-    implementation("io.ktor:ktor-gson:$ktorVersion")
-    implementation("io.ktor:ktor-locations:$ktorVersion")
-    implementation("io.ktor:ktor-auth-jwt:$ktorVersion")
+    implementation("io.ktor:ktor-server-auth-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-auth-jwt-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-resources:$ktorVersion")
+    implementation("io.ktor:ktor-server-swagger-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
     implementation("io.insert-koin:koin-ktor:$koinVersion")
 
-    testImplementation("io.ktor:ktor-server-tests:$ktorVersion")
+    testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
 }

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/controller/UserController.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/controller/UserController.kt
@@ -3,7 +3,7 @@ package br.com.amz.ktorplate.web.controller
 import br.com.amz.ktorplate.exception.PreConditionFailedException
 import br.com.amz.ktorplate.usecases.service.UserService
 import br.com.amz.ktorplate.user.User
-import io.ktor.features.NotFoundException
+import io.ktor.server.plugins.NotFoundException
 
 class UserController(private val userService: UserService) {
 

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/route/LoginRoutes.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/route/LoginRoutes.kt
@@ -3,16 +3,15 @@ package br.com.amz.ktorplate.web.route
 import br.com.amz.ktorplate.web.controller.LoginController
 import br.com.amz.ktorplate.web.dto.LoginRequest
 import br.com.amz.ktorplate.web.dto.SignUpRequest
-import io.ktor.application.call
-import io.ktor.request.receive
-import io.ktor.response.respond
-import io.ktor.routing.Routing
-import io.ktor.routing.post
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.post
 import org.koin.ktor.ext.inject
 
 fun Routing.loginApis() {
-    val loginController: LoginController by inject()
+    val loginController: LoginController by this.inject()
 
     post("/signup") {
         val request = call.receive<SignUpRequest>()

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/route/UserRoutes.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/route/UserRoutes.kt
@@ -1,18 +1,17 @@
 package br.com.amz.ktorplate.web.route
 
 import br.com.amz.ktorplate.web.controller.UserController
-import io.ktor.application.call
-import io.ktor.auth.authenticate
-import io.ktor.locations.KtorExperimentalLocationsAPI
-import io.ktor.locations.Location
-import io.ktor.locations.get
-import io.ktor.response.respond
-import io.ktor.routing.Routing
-import io.ktor.routing.get
-import io.ktor.routing.route
+import io.ktor.resources.Resource
+import io.ktor.server.application.call
+import io.ktor.server.auth.authenticate
+import io.ktor.server.resources.get
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
 import org.koin.ktor.ext.inject
 
-@KtorExperimentalLocationsAPI
 fun Routing.userApis() {
     val userController: UserController by inject()
 
@@ -21,12 +20,12 @@ fun Routing.userApis() {
             get { call.respond(userController.getUsers()) }
 
             get<UserParam> {
-                call.respond(userController.getUserByEmail(this.context.parameters["userEmail"].toString()))
+                call.respond(userController.getUserByEmail(this.context.parameters["email"]!!))
             }
         }
     }
 }
 
-@KtorExperimentalLocationsAPI
-@Location("/{userEmail}")
-data class UserParam(val userEmail: String)
+@Serializable
+@Resource("/{email}")
+data class UserParam(val email: String)

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/server/Module.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/server/Module.kt
@@ -47,15 +47,7 @@ fun Application.module() {
         }
     }
 
-    authentication {
-        jwt {
-            val jwtSecret = env.getString("jwt.secret")
-
-            JWTCredential(jwtSecret).also { verifier(it.verifier) }
-            validate { JWTPrincipal(it.payload) }
-        }
-    }
-
+    configureAuthentication()
     configureRouting()
 }
 
@@ -67,5 +59,16 @@ fun Application.configureRouting() {
 
         loginApis()
         userApis()
+    }
+}
+
+fun Application.configureAuthentication() {
+    authentication {
+        jwt {
+            val jwtSecret = env.getString("jwt.secret")
+
+            verifier(JWTCredential(jwtSecret).verifier)
+            validate { JWTPrincipal(it.payload) }
+        }
     }
 }

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/server/Module.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/server/Module.kt
@@ -63,7 +63,7 @@ fun Application.configureRouting() {
     routing {
         get("/health") { call.respond(mapOf("status" to "OK")) }
 
-        swaggerUI(path = "openapi")
+        swaggerUI(path = "/swagger")
 
         loginApis()
         userApis()

--- a/web/src/main/kotlin/br/com/amz/ktorplate/web/server/ServerBoot.kt
+++ b/web/src/main/kotlin/br/com/amz/ktorplate/web/server/ServerBoot.kt
@@ -4,7 +4,7 @@ import io.ktor.server.netty.EngineMain
 
 object ServerBoot {
 
-    fun boot(args: Array<String>){
+    fun boot(args: Array<String>) {
         EngineMain.main(args)
     }
 }

--- a/web/src/main/resources/openapi/documentation.yaml
+++ b/web/src/main/resources/openapi/documentation.yaml
@@ -1,0 +1,81 @@
+openapi: "3.0.3"
+info:
+  title: "Ktorplate APIs"
+  description: "All APIs from Ktorplate in a single place"
+  version: "1.0.0"
+
+servers:
+  - url: "http://0.0.0.0:8080"
+paths:
+  /signup:
+    post:
+      summary: Creates a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignUpRequest'
+      responses:
+        '201':
+          description: User created
+  /login:
+    post:
+      summary: Authenticates an user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authentication succeeded
+  /users:
+    get:
+      summary: Get a list of all users
+      responses:
+        '200':
+          description: Users list
+  /users/{email}:
+    get:
+      summary: Get an user by its email
+      parameters:
+        - in: path
+          name: email
+          required: true
+          description: User's email address
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User found
+        '404':
+          description: User not found
+  /health:
+    get:
+      summary: Health API
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    SignUpRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+        password:
+          type: string
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+        password:
+          type: string

--- a/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
+++ b/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
@@ -5,13 +5,11 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
-import org.junit.Assert.assertEquals
-import org.junit.Ignore
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ApplicationTest {
 
-    @Ignore
     @Test
     fun testRoot() = testApplication {
         application {

--- a/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
+++ b/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
@@ -1,5 +1,6 @@
 package br.com.amz.ktorplate
 
+import br.com.amz.ktorplate.web.server.configureAuthentication
 import br.com.amz.ktorplate.web.server.configureRouting
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -13,6 +14,7 @@ class ApplicationTest {
     @Test
     fun testRoot() = testApplication {
         application {
+            configureAuthentication()
             configureRouting()
         }
 

--- a/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
+++ b/web/src/test/kotlin/br/com/amz/ktorplate/ApplicationTest.kt
@@ -1,28 +1,26 @@
 package br.com.amz.ktorplate
 
-import br.com.amz.ktorplate.web.server.module
-import io.ktor.http.HttpMethod
+import br.com.amz.ktorplate.web.server.configureRouting
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import io.ktor.locations.KtorExperimentalLocationsAPI
-import io.ktor.server.testing.handleRequest
-import io.ktor.server.testing.withTestApplication
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.server.testing.testApplication
+import org.junit.Assert.assertEquals
 import org.junit.Ignore
 import org.junit.Test
-import kotlin.test.assertEquals
 
-@KtorExperimentalAPI
-@KtorExperimentalLocationsAPI
 class ApplicationTest {
 
     @Ignore
     @Test
-    fun testRoot() {
-        withTestApplication({ module() }) {
-            handleRequest(HttpMethod.Get, "/health").apply {
-                assertEquals(HttpStatusCode.OK, response.status())
-                assertEquals("{\"status\":\"OK\"}", response.content)
-            }
+    fun testRoot() = testApplication {
+        application {
+            configureRouting()
+        }
+
+        client.get("/health").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertEquals("\"status\": \"OK\"", bodyAsText())
         }
     }
 }


### PR DESCRIPTION
This PR aims to bump almost every dependencies in the project. Some of them (Ktor, Coin for example) required a few code changes, but in general nothing else changed. Here are the libraries updated:

- **Gradle:** from 6.4 to 7.5
- **Kotlin:** from 1.3.72 to 1.9.0
- **Ktor:** from 1.3.2 to 2.3.4
- **Koin:** from 2.1.6 to 3.5.0
- **Typesafe Config:** from 1.4.0 to 1.4.2
- **Kotlinx Coroutines:** from 1.3.7 to 1.7.3
- **LogBack:** from 1.2.1 to 1.4.11
- **Exposed:** from 0.17.7 to 0.43.0
- **Hikari:** from 3.4.5 to 5.0.1
- **PostgreSQL:** from 42.2.2 to 42.6.0
- **Flyway:** from 6.4.0 to 9.22.2
- **Auth0**: from 3.10.3 to 4.4.0

It also includes a new api `/swagger` where you can find the entire documentation for all APIs we have.